### PR TITLE
Sync

### DIFF
--- a/src/components/accordion.tsx
+++ b/src/components/accordion.tsx
@@ -25,9 +25,9 @@ export default function Accordion({
   }, [center, open]);
 
   return (
-    <div ref={ref}>
+    <div ref={ref} className="pt-4">
       <div
-        className="mx-auto mb-5 flex cursor-pointer select-none items-center justify-between gap-4 rounded-2xl bg-gray-5 px-4 py-3 text-violet-400"
+        className="mx-auto flex cursor-pointer select-none items-center justify-between gap-4 rounded-2xl bg-gray-5 px-4 py-3 text-violet-400"
         onClick={() => setOpen((prevState) => !prevState)}
       >
         <h2 className="font-bold">{title}</h2>

--- a/src/components/heros/home-hero-section.tsx
+++ b/src/components/heros/home-hero-section.tsx
@@ -31,7 +31,7 @@ export default function HomeHeroSection() {
 
   return (
     <>
-      <section className="realtive flex h-[calc(100dvh-5rem)] items-center justify-center">
+      <section className="realtive flex h-[calc(100svh-5rem)] items-center justify-center">
         <div className="max-w-max">
           <h1 className="mx-auto text-center text-5xl font-bold text-theme-contrary sm:text-7xl md:text-8xl">
             Team Frontend.

--- a/src/components/heros/home-hero-section.tsx
+++ b/src/components/heros/home-hero-section.tsx
@@ -24,8 +24,10 @@ export default function HomeHeroSection() {
   const isInView = useIsInView(ref);
 
   const { searchParams } = useUpdateSearchParams();
-  const uxEffects =
-    searchParams.get('uxEffects') && searchParams.get('uxEffects') === 'true';
+
+  const uxEffects = !!(
+    searchParams.get('uxEffects') && searchParams.get('uxEffects') === 'true'
+  );
 
   return (
     <>

--- a/src/components/more-items-section.tsx
+++ b/src/components/more-items-section.tsx
@@ -34,6 +34,7 @@ export default function MoreItemsSection({
           {state.isVisible && <MinusIcon className="h-4 w-4" />}
           {!state.isVisible && <PlusIcon className="h-4 w-4" />}
         </button>
+
         <button
           aria-label="Hide and show more items"
           className="rounded-full bg-gray-5 p-4 px-6 transition hover:text-theme-contrary"
@@ -42,20 +43,18 @@ export default function MoreItemsSection({
         </button>
       </div>
 
-      <ul
-        className={`transition ${
-          state.isVisible ? 'visible translate-y-0' : 'invisible translate-y-6'
-        }`}
-      >
-        {items.map((item) => {
-          if (item.priority === 'low')
-            return (
-              <li key={item.title}>
-                <RowItem rowItem={item} />
-              </li>
-            );
-        })}
-      </ul>
+      {state.isVisible && (
+        <ul className="animate-fadeUp">
+          {items.map((item) => {
+            if (item.priority === 'low')
+              return (
+                <li key={item.title}>
+                  <RowItem rowItem={item} />
+                </li>
+              );
+          })}
+        </ul>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
This update adds:

- fix(Spacing) – Remove empty space in `more-items-section` for not visible elements
- fix(Accordion) – Add empty space at top for scroll-into-view Accordion element
- fix(Scrolling) – Remove layout shift when scrolling on mobile by `svh` css property instead of `dvh`